### PR TITLE
feat/reset-password - password reset

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -1,5 +1,10 @@
 import { Request, Response } from 'express';
-import { handleEmailLogin, handleEmailSignUp, verifyEmailToken } from '../services/AuthService';
+import {
+   checkUserForResetPassword,
+   handleEmailLogin,
+   handleEmailSignUp,
+   verifyEmailToken,
+} from '../services/AuthService';
 import httpStatus from 'http-status';
 import dotenv from 'dotenv';
 import jwt from 'jsonwebtoken';
@@ -139,6 +144,21 @@ export const logout = async (req: Request, res: Response): Promise<void> => {
       console.error('❌ 로그아웃 중 오류 발생:', error);
       res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
          message: '로그아웃 실패',
+         error,
+      });
+   }
+};
+
+export const resetPassword = async (req: Request, res: Response): Promise<void> => {
+   try {
+      const { email } = req.body;
+
+      checkUserForResetPassword({ email });
+      res.status(httpStatus.OK).json({ message: '비밀번호 초기화 완료' });
+   } catch (error) {
+      console.error('❌ 로그아웃 중 오류 발생:', error);
+      res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+         message: '비밀번호 초기화 실패',
          error,
       });
    }

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -1,4 +1,6 @@
 import User from '../Model/User';
+import crypto from 'crypto';
+import bcrypt from 'bcrypt';
 
 export const createUser = async (userData: Partial<User>): Promise<User> => {
    try {
@@ -32,5 +34,27 @@ export const findUserByEmail = async (email: string): Promise<User | null> => {
    } catch (error) {
       console.error('❌ 사용자 이메일 조회 중 오류 발생:', error);
       throw new Error('사용자 조회 실패');
+   }
+};
+
+export const sendNewPassword = async (email: string): Promise<{ user: User; newPassword: string } | null> => {
+   try {
+      const user = await User.findOne({ where: { email, social_provider: 'self' } });
+
+      if (!user) throw new Error('해당 메일 주소를 가진 회원 정보가 존재하지 않습니다.');
+
+      const newPassword = crypto
+         .randomBytes(9)
+         .toString('base64')
+         .replace(/[^a-zA-Z0-9]/g, '')
+         .slice(0, 12);
+
+      const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+      await user.update({ password: hashedPassword });
+      return { user, newPassword };
+   } catch (error) {
+      console.error('❌ 비밀번호 초기화 실패:', error);
+      throw new Error('비밀번호 초기화 실패');
    }
 };

--- a/src/routes/AuthRoutes.ts
+++ b/src/routes/AuthRoutes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { emailLogin, emailSignUp, logout, verifyEmail } from '../controllers/AuthController';
+import { emailLogin, emailSignUp, logout, resetPassword, verifyEmail } from '../controllers/AuthController';
 
 const router = express.Router();
 
@@ -7,5 +7,6 @@ router.post('/signup', emailSignUp);
 router.get('/verify-email', verifyEmail);
 router.post('/login', emailLogin);
 router.post('/logout', logout);
+router.post('/resetPassword', resetPassword);
 
 export default router;


### PR DESCRIPTION
### PR 종류

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

### 핵심 내용

- 비밀번호 초기화 기능 구현

### 부가 설명

- 사용자가 이메일로 비밀번호 초기화를 요청하면, 데이터베이스에서 해당 이메일과 social_provider가 self인 사용자를 조회

- 12자리 난수(대문자, 소문자, 숫자 포함)로 임시 비밀번호 생성

- bcrypt를 사용하여 생성된 비밀번호를 해시화하고 데이터베이스에 저장

- 해시화 전 원본 비밀번호를 이메일로 사용자에게 발송

- 발송 이메일 예시

  ![image](https://github.com/user-attachments/assets/c5ac8e68-29e5-4bdf-bdd4-01fc3c2fb260)

