### PR TITLE
feat/popular-keyword - 인기 검색어 DB 저장 로직 구현

### DIFF
--- a/src/Model/PopularKeyword.ts
+++ b/src/Model/PopularKeyword.ts
@@ -1,0 +1,39 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database';
+
+class PopularKeyword extends Model {
+   public id!: number;
+   public keyword!: string;
+   public search_count!: number;
+   public last_searched!: Date;
+}
+
+PopularKeyword.init(
+   {
+      id: {
+         type: DataTypes.INTEGER,
+         autoIncrement: true,
+         primaryKey: true,
+      },
+      keyword: {
+         type: DataTypes.STRING(255),
+         allowNull: false,
+         unique: true,
+      },
+      search_count: {
+         type: DataTypes.INTEGER,
+         defaultValue: 1,
+      },
+      last_searched: {
+         type: DataTypes.DATE,
+         defaultValue: DataTypes.NOW,
+      },
+   },
+   {
+      sequelize,
+      tableName: 'popular_keywords',
+      timestamps: false,
+   },
+);
+
+export default PopularKeyword;

--- a/src/controllers/popularKeyword/PopularKeywordController.ts
+++ b/src/controllers/popularKeyword/PopularKeywordController.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express';
+import PopularKeywordService from '../../services/popularKeyword/PopularKeywordService';
+import httpStatus from 'http-status';
+
+class PopularKeywordController {
+   /**
+    * 검색어 저장 API (`GET /popular-keyword?keyword=example`)
+    */
+   saveKeyword = async (req: Request, res: Response): Promise<void> => {
+      try {
+         const { keyword } = req.query;
+         if (!keyword || typeof keyword !== 'string') {
+            res.status(httpStatus.BAD_REQUEST).json({ success: false, message: '검색어가 필요합니다.' });
+            return;
+         }
+
+         const savedKeyword = await PopularKeywordService.saveKeyword(keyword);
+         res.status(httpStatus.OK).json({ success: true, data: savedKeyword });
+      } catch (error) {
+         console.error('❌ 검색어 저장 실패:', error);
+         res.status(httpStatus.INTERNAL_SERVER_ERROR).json({ success: false, message: '서버 오류 발생' });
+      }
+   };
+
+   /**
+    * 인기 검색어 조회 API (`GET /popular-keyword/popular`)
+    */
+   getPopularKeywords = async (req: Request, res: Response): Promise<void> => {
+      try {
+         const keywords = await PopularKeywordService.getPopularKeywords();
+         res.status(httpStatus.OK).json({ success: true, data: keywords });
+      } catch (error) {
+         console.error('❌ 인기 검색어 조회 실패:', error);
+         res.status(httpStatus.INTERNAL_SERVER_ERROR).json({ success: false, message: '서버 오류 발생' });
+      }
+   };
+}
+
+export default new PopularKeywordController();

--- a/src/repositories/popularKeyword/PopularKeywordRepository.ts
+++ b/src/repositories/popularKeyword/PopularKeywordRepository.ts
@@ -1,0 +1,43 @@
+import PopularKeyword from '../../Model/PopularKeyword';
+
+class PopularKeywordRepository {
+   /**
+    * 검색어를 저장하거나 검색 횟수를 증가시키는 메서드
+    * @param keyword 검색어
+    */
+   async saveKeyword(keyword: string): Promise<PopularKeyword> {
+      try {
+         const [popularKeyword, created] = await PopularKeyword.findOrCreate({
+            where: { keyword },
+            defaults: { search_count: 1 },
+         });
+
+         if (!created) {
+            await popularKeyword.increment('search_count');
+            await popularKeyword.update({ last_searched: new Date() });
+         }
+
+         return popularKeyword;
+      } catch (error) {
+         console.error('❌ 인기 검색어 저장 오류:', error);
+         throw new Error('데이터베이스 처리 중 오류 발생');
+      }
+   }
+
+   /**
+    * 인기 검색어 TOP 10 조회
+    */
+   async getPopularKeywords(): Promise<PopularKeyword[]> {
+      try {
+         return await PopularKeyword.findAll({
+            order: [['search_count', 'DESC']],
+            limit: 10,
+         });
+      } catch (error) {
+         console.error('❌ 인기 검색어 조회 오류:', error);
+         throw new Error('인기 검색어를 불러오는 중 오류 발생');
+      }
+   }
+}
+
+export default new PopularKeywordRepository();

--- a/src/routes/PopularKeywordRoutes.ts
+++ b/src/routes/PopularKeywordRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import PopularKeywordController from '../controllers/popularKeyword/PopularKeywordController';
+
+const router = Router();
+
+router.get('/', PopularKeywordController.saveKeyword);
+router.get('/popular', PopularKeywordController.getPopularKeywords);
+
+export default router;

--- a/src/services/popularKeyword/PopularKeywordService.ts
+++ b/src/services/popularKeyword/PopularKeywordService.ts
@@ -1,0 +1,24 @@
+import PopularKeywordRepository from '../../repositories/popularKeyword/PopularKeywordRepository';
+
+class PopularKeywordService {
+   /**
+    * 검색어 저장 비즈니스 로직
+    * @param keyword 검색어
+    */
+   async saveKeyword(keyword: string) {
+      if (!keyword || keyword.trim() === '') {
+         throw new Error('검색어를 입력해야 합니다.');
+      }
+
+      return await PopularKeywordRepository.saveKeyword(keyword);
+   }
+
+   /**
+    * 인기 검색어 조회 비즈니스 로직
+    */
+   async getPopularKeywords() {
+      return await PopularKeywordRepository.getPopularKeywords();
+   }
+}
+
+export default new PopularKeywordService();


### PR DESCRIPTION
### PR 종류

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

### 핵심 내용

- 사용자가 검색창에 입력한 키워드를 데이터베이스에 저장하고, 검색 횟수를 누적하여 인기 검색어를 관리하는 기능 추가
- GET /popular-keyword?keyword=검색어 → 검색어 저장 및 검색 횟수 증가
- GET /popular-keyword/popular → 인기 검색어 TOP 10 조회

### 부가 설명

- Sequelize 기반으로 구현 (findOrCreate, increment 사용)
- 검색어 저장 시 중복 방지 (동일한 키워드 입력 시 search_count 증가)
- last_searched 컬럼을 추가하여 최근 검색 시간을 기록
- PopularKeywordController, PopularKeywordService, PopularKeywordRepository 구조로 역할 분리




- 인기 검색어 DB 저장
  ![image](https://github.com/user-attachments/assets/6024f08f-79d4-49bd-a9ad-8831f6990527)


- 인기 검색어 조회
  ![image](https://github.com/user-attachments/assets/632fc84f-2744-4cd0-96ca-66ea0c5f983c)

