### PR TITLE
feat/user 마이페이지 - 회원정보수정하기 기능 변경

### DIFF
--- a/src/repositories/user/UserRepository.ts
+++ b/src/repositories/user/UserRepository.ts
@@ -13,9 +13,14 @@ class UserRepository {
       }
    }
 
-   async updateUserInfo(userId: number, password: string, location: string): Promise<void> {
+   async updateUserInfo(userId: number, password: string | undefined, location: string): Promise<void> {
       try {
-         await User.update({ password, location: location }, { where: { id: userId } });
+         const updateData: { password?: string; location: string } = { location };
+         if (password) {
+            updateData.password = password;
+         }
+
+         await User.update(updateData, { where: { id: userId } });
       } catch (error) {
          console.error('회원 정보 업데이트 실패 : ', error);
          throw new Error('회원 정보 업데이트 실패');

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -8,8 +8,14 @@ class UserService {
       return userInfo;
    }
 
-   async updateUserInfo(userId: number, password: string, location: string): Promise<void> {
-      const hashedPassword = await bcrypt.hash(password, 10); // 비밀번호 해싱
+   async updateUserInfo(userId: number, password: string | undefined, location: string): Promise<void> {
+      let hashedPassword: string | undefined;
+
+      // 비밀번호가 있을 때만 해싱
+      if (password) {
+         hashedPassword = await bcrypt.hash(password, 10);
+      }
+
       await UserRepository.updateUserInfo(userId, hashedPassword, location);
    }
 }


### PR DESCRIPTION
### PR 종류

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other

### 핵심 내용

- 서버 사이드에서 비밀번호 없이도 거주 지역(location) 정보만 수정 가능하도록 로직 수정
- 비밀번호가 전달되지 않는 경우 해싱을 수행하지 않도록 변경
- bcrypt.hash 함수 호출 시 password가 존재하는 경우에만 해싱을 수행하여 오류 방지