### PR TITLE
feat/user - 마이페이지(상품관리탭) - 상품 판매중지/판매재개/삭제 로직 통합

### DIFF
--- a/src/controllers/product/ProductController.ts
+++ b/src/controllers/product/ProductController.ts
@@ -158,7 +158,7 @@ class ProductController {
    }
 
    /**
-    * 상품 상태 업데이트 (판매중 / 판매중지)
+    * 상품 상태 업데이트 (판매중 / 판매중지 / 삭제)
     * @route PATCH /product/mypage/product/:id/status
     */
    async updateProductStatus(req: Request, res: Response): Promise<void> {
@@ -167,38 +167,27 @@ class ProductController {
          const { status } = req.body;
 
          // 상태 값 검증
-         const allowedStatuses = ['available', 'stopped'];
+         const allowedStatuses = ['available', 'stopped', 'deleted'];
          if (!allowedStatuses.includes(status)) {
-            res.status(httpStatus.BAD_REQUEST).json({
-               message: `잘못된 상태값입니다. (${allowedStatuses.join(', ')} 중 하나여야 합니다.)`,
-            });
+            if (!res.headersSent) {
+               res.status(httpStatus.BAD_REQUEST).json({
+                  message: `잘못된 상태값입니다. (${allowedStatuses.join(', ')} 중 하나여야 합니다.)`,
+               });
+            }
          }
 
-         await ProductService.updateProductStatus(Number(id), status as 'available' | 'stopped');
-         res.status(httpStatus.OK).json({ message: `상품 상태가 '${status}'로 변경되었습니다.` });
+         await ProductService.updateProductStatus(Number(id), status as 'available' | 'stopped' | 'deleted');
+
+         if (!res.headersSent) {
+            res.status(httpStatus.OK).json({ message: `상품 상태가 '${status}'로 변경되었습니다.` });
+         }
       } catch (error) {
          console.error('❌ 상품 상태 업데이트 실패:', error);
-         res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
-            message: '상품 상태 업데이트 중 오류가 발생했습니다.',
-         });
-      }
-   }
-
-   /**
-    * 마이페이지 - 상품 삭제
-    * @route DELETE /product/:id
-    */
-   async deleteProduct(req: Request, res: Response): Promise<void> {
-      try {
-         const { id } = req.params;
-         console.log('마이페이지 - 상품 삭제 : ', id);
-         await ProductService.deleteProduct(Number(id));
-         res.status(httpStatus.OK).json({ message: '상품이 삭제되었습니다.' });
-      } catch (error) {
-         console.error('❌ 상품 삭제 실패:', error);
-         res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
-            message: '상품 삭제 중 오류가 발생했습니다.',
-         });
+         if (!res.headersSent) {
+            res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+               message: '상품 상태 업데이트 중 오류가 발생했습니다.',
+            });
+         }
       }
    }
 }

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -17,7 +17,7 @@ class Product extends Model {
    public favorite_cnt!: number; // 좋아요 수
    public seller_id!: number; // 판매자 ID (User 참조)
    public trade_loc!: string; // 거래 희망 장소
-   public trade_status!: 'available' | 'reserved' | 'completed' | 'stopped'; // 거래 상태 (판매중, 예약중, 판매완료, 판매중지 )
+   public trade_status!: 'available' | 'reserved' | 'completed' | 'stopped' | 'deleted'; // 거래 상태 (판매중, 예약중, 판매완료, 판매중지 )
    public trade_complete_date?: Date; // 거래 완료 날짜 (선택적)
    public trade_method!: string; // 거래 방식 (e.g., 직거래, 택배 거래)
    public buyer_id?: number; // 구매자 ID (User 참조, 선택적)
@@ -89,10 +89,11 @@ Product.init(
          allowNull: false,
       },
       trade_status: {
-         type: DataTypes.ENUM('available', 'reserved', 'completed', 'stopped'),
+         type: DataTypes.ENUM('available', 'reserved', 'completed', 'stopped', 'deleted'),
          allowNull: false,
          defaultValue: 'available',
       },
+
       trade_complete_date: {
          type: DataTypes.DATE,
          allowNull: true,

--- a/src/repositories/product/ProductRepository.ts
+++ b/src/repositories/product/ProductRepository.ts
@@ -116,7 +116,12 @@ class ProductRepository {
    async findUserProductsByStatus(userId: number, status: string) {
       try {
          return await Product.findAll({
-            where: { seller_id: userId, trade_status: status },
+            where: {
+               seller_id: userId,
+               trade_status: {
+                  [Op.and]: [status, { [Op.not]: 'deleted' }],
+               },
+            },
             order: [['product_reg_date', 'DESC']],
          });
       } catch (error) {
@@ -138,29 +143,14 @@ class ProductRepository {
    }
 
    /**
-    * 상품 상태 업데이트 (판매중 / 판매중지)
+    * 상품 상태 업데이트 (판매중, 판매중지, 삭제)
     */
-   async updateProductStatus(productId: number, status: 'available' | 'stopped'): Promise<void> {
+   async updateProductStatus(productId: number, status: 'available' | 'stopped' | 'deleted'): Promise<void> {
       try {
          await Product.update({ trade_status: status }, { where: { id: productId } });
       } catch (error) {
          console.error('❌ 상품 상태 업데이트 실패:', error);
          throw new Error('상품 상태 업데이트 중 오류가 발생했습니다.');
-      }
-   }
-
-   /**
-    * 상품 삭제
-    */
-   async deleteProduct(productId: number): Promise<void> {
-      try {
-         const result = await Product.destroy({ where: { id: productId } });
-         if (result === 0) {
-            throw new Error('삭제할 상품을 찾을 수 없습니다.');
-         }
-      } catch (error) {
-         console.error('❌ 상품 삭제 실패:', error);
-         throw new Error('상품 삭제 중 오류가 발생했습니다.');
       }
    }
 }

--- a/src/routes/ProductRoutes.ts
+++ b/src/routes/ProductRoutes.ts
@@ -14,7 +14,6 @@ router.delete('/favorite/:id', verifyToken, ProductController.removeFavorite);
 // 마이페이지 - 상품 관리 탭
 router.get('/mypage/products/all', verifyToken, ProductController.getUserProducts);
 router.get('/mypage/products/:status', verifyToken, ProductController.getUserProductsByStatus);
-router.delete('/mypage/product/:id', verifyToken, ProductController.deleteProduct);
 router.patch('/mypage/product/:id/status', verifyToken, ProductController.updateProductStatus);
 
 export default router;

--- a/src/services/product/ProductService.ts
+++ b/src/services/product/ProductService.ts
@@ -73,7 +73,10 @@ class ProductService {
       return products.map((product) => product.toJSON());
    }
 
-   async updateProductStatus(productId: number, status: 'available' | 'stopped'): Promise<void> {
+   /**
+    * 상품 상태 업데이트 (판매중, 판매중지, 삭제)
+    */
+   async updateProductStatus(productId: number, status: 'available' | 'stopped' | 'deleted'): Promise<void> {
       try {
          const product = await ProductRepository.findProductById(productId);
          if (!product) {
@@ -85,13 +88,6 @@ class ProductService {
          console.error('❌ 상품 상태 업데이트 실패:', error);
          throw new Error('상품 상태 업데이트 중 오류가 발생했습니다.');
       }
-   }
-
-   /**
-    * 상품 삭제
-    */
-   async deleteProduct(productId: number): Promise<void> {
-      await ProductRepository.deleteProduct(productId);
    }
 }
 


### PR DESCRIPTION
### PR 종류

- [ ] 🐞 Bugfix
- [ ] ✨ New Feature
- [ ] 📚 Documentation
- [x] ♻️ Refactoring
- [ ] 🧪 Other

### 핵심 내용

- 상품 상태 변경(판매중지, 판매재개, 삭제) 로직을 통합하여 하나의 API에서 처리하도록 개선
- `PATCH` `/product/mypage/product/:id/status` 엔드포인트에서 `trade_status`를 `'available'`, `'stopped'`, `'deleted'`로 변경 가능

### 부가 설명

- 기존의 deleteProduct 메서드를 `제거`하고, updateProductStatus 메서드로 상태 변경을 `통합`
- deleted 상태의 상품은 DB에서는 남아있지만, 화면에는 노출되지 않도록 처리
- 모든 상품 조회 시 trade_status !== 'deleted' 조건을 추가하여 삭제된 상품은 제외
- 상품 상태 변경 시 통합된 updateProductStatus 메서드를 통해 상태를 일관되게 관리
