### PR TITLE
refactoring/login - 비밀번호 재설정 로직 재구성

### DIFF
--- a/src/controllers/login/AuthController.ts
+++ b/src/controllers/login/AuthController.ts
@@ -106,6 +106,7 @@ export const emailLogin = async (req: Request, res: Response): Promise<void> => 
          user_id: user.user_id,
          email: user.email,
          nickname: user.nickname,
+         password_reset: user.password_reset,
       };
 
       res.cookie('accessToken', token, {
@@ -121,7 +122,6 @@ export const emailLogin = async (req: Request, res: Response): Promise<void> => 
       });
 
       console.log('✅ 로그인 성공:', filteredUser);
-
       res.status(httpStatus.OK).json({
          message: '로그인 성공',
          status: 'success',
@@ -153,8 +153,7 @@ export const logout = async (req: Request, res: Response): Promise<void> => {
 export const resetPassword = async (req: Request, res: Response): Promise<void> => {
    try {
       const { email } = req.body;
-
-      checkUserForResetPassword({ email });
+      await checkUserForResetPassword({ email });
       res.status(httpStatus.OK).json({ message: '비밀번호 초기화 완료' });
    } catch (error) {
       console.error('❌ 로그아웃 중 오류 발생:', error);

--- a/src/controllers/user/UserController.ts
+++ b/src/controllers/user/UserController.ts
@@ -22,7 +22,10 @@ class UserController {
       try {
          const { password, location } = req.body;
          const userId = (req.user as JwtPayload & { id: number })?.id;
-         await UserService.updateUserInfo(userId, password, location);
+
+         const password_reset = req.body.password_reset === true;
+
+         await UserService.updateUserInfo(userId, password, location, password_reset);
          res.status(httpStatus.OK).json({ message: '회원정보 업데이트 성공' });
       } catch (error) {
          console.error('회원 정보 업데이트 실패 : ', error);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -16,6 +16,7 @@ class User extends Model {
    public verified!: boolean;
    public emailToken!: string;
    public location!: string;
+   public password_reset!: boolean;
 }
 
 User.init(
@@ -77,6 +78,11 @@ User.init(
       },
       location: {
          type: DataTypes.STRING,
+      },
+      password_reset: {
+         type: DataTypes.BOOLEAN,
+         defaultValue: false,
+         allowNull: false,
       },
    },
    {

--- a/src/repositories/login/AuthRepository.ts
+++ b/src/repositories/login/AuthRepository.ts
@@ -51,7 +51,7 @@ export const sendNewPassword = async (email: string): Promise<{ user: User; newP
 
       const hashedPassword = await bcrypt.hash(newPassword, 10);
 
-      await user.update({ password: hashedPassword });
+      await user.update({ password: hashedPassword, password_reset: true });
       return { user, newPassword };
    } catch (error) {
       console.error('❌ 비밀번호 초기화 실패:', error);

--- a/src/repositories/user/UserRepository.ts
+++ b/src/repositories/user/UserRepository.ts
@@ -13,11 +13,29 @@ class UserRepository {
       }
    }
 
-   async updateUserInfo(userId: number, password: string | undefined, location: string): Promise<void> {
+   /**
+    * 회원 정보 업데이트
+    * @param userId 사용자 ID
+    * @param password 암호화된 비밀번호 (선택적)
+    * @param location 업데이트할 위치 정보
+    * @param resetPassword 비밀번호 초기화 상태를 false로 변경할지 여부
+    */
+   async updateUserInfo(
+      userId: number,
+      password: string | undefined,
+      location: string,
+      password_reset?: boolean, // 선택적(optional)으로 변경
+   ): Promise<void> {
       try {
-         const updateData: { password?: string; location: string } = { location };
+         const updateData: { password?: string; location: string; password_reset?: boolean } = { location };
+
          if (password) {
             updateData.password = password;
+         }
+
+         // password_reset이 정의된 경우에만 업데이트 데이터에 추가
+         if (typeof password_reset === 'boolean') {
+            updateData.password_reset = password_reset;
          }
 
          await User.update(updateData, { where: { id: userId } });

--- a/src/services/login/AuthService.ts
+++ b/src/services/login/AuthService.ts
@@ -96,7 +96,16 @@ export const handleEmailLogin = async ({ email, password }: { email: string; pas
 
    const token = generateTokens(user);
 
-   return { token, user: { id: user.id, user_id: user.user_id, email: user.email, nickname: user.nickname } };
+   return {
+      token,
+      user: {
+         id: user.id,
+         user_id: user.user_id,
+         email: user.email,
+         nickname: user.nickname,
+         password_reset: user.password_reset,
+      },
+   };
 };
 
 export const checkUserForResetPassword = async ({ email }: { email: string }) => {

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -8,15 +8,27 @@ class UserService {
       return userInfo;
    }
 
-   async updateUserInfo(userId: number, password: string | undefined, location: string): Promise<void> {
+   /**
+    * 회원 정보 업데이트
+    * @param userId 사용자 ID
+    * @param password 새로운 비밀번호 (선택적)
+    * @param location 새로운 위치 정보
+    * @param password_reset 비밀번호 초기화 상태 (선택적)
+    */
+   async updateUserInfo(
+      userId: number,
+      password: string | undefined,
+      location: string,
+      password_reset?: boolean, // 선택적(optional)으로 변경
+   ): Promise<void> {
       let hashedPassword: string | undefined;
 
-      // 비밀번호가 있을 때만 해싱
       if (password) {
          hashedPassword = await bcrypt.hash(password, 10);
       }
 
-      await UserRepository.updateUserInfo(userId, hashedPassword, location);
+      // Repository로 전달 시 선택적 속성으로 전달
+      await UserRepository.updateUserInfo(userId, hashedPassword, location, password_reset);
    }
 }
 


### PR DESCRIPTION
### PR 종류

- [ ] 🐞 Bugfix
- [x] ✨ New Feature
- [ ] 📚 Documentation
- [x] ♻️ Refactoring
- [ ] 🧪 Other

### 핵심 내용

- 비밀번호 초기화(resetPassword) 시 `password_reset` 값을 `true`로 설정
- 사용자가 비밀번호 변경 시 자동으로 `password_reset` 값을 `false`로 변경
- 비밀번호 변경 완료 후 다시 비밀번호 변경 안내 메시지가 나타나지 않도록 수정

### 부가 설명

- 비밀번호 초기화 후 사용자가 로그인을 시도할 때 반드시 새 비밀번호를 설정하도록 강제.
- 사용자가 비밀번호를 성공적으로 변경하면 password_reset 값이 `false`로 전환
- password_reset값을 클라이언트 사이드로 전달
